### PR TITLE
記事「引用をスッとできる人に憧れている」にh1タイトルを追加

### DIFF
--- a/app/routes/posts/20260507.mdx
+++ b/app/routes/posts/20260507.mdx
@@ -3,6 +3,8 @@ title: 引用をスッとできる人に憧れている
 date: 2026-05-07
 ---
 
+# 引用をスッとできる人に憧れている
+
 お気に入りのPodCastとして、「超相対性理論」、「To The Lighthouse」 というPodCast番組がある
 
 [超相対性理論 \| Podcast on Spotify](https://open.spotify.com/show/5xCiKGwndGU37pIuJTXpmD)


### PR DESCRIPTION
## 概要

- 記事「引用をスッとできる人に憧れている」(20260507.mdx) の冒頭にh1見出しがなかったので追加

## 変更内容

- frontmatter直後に `# 引用をスッとできる人に憧れている` を追加
- 記事本文の変更はなし

## 確認方法

- `pnpm dev` でローカル起動し、該当記事ページでh1タイトルが表示されることを確認